### PR TITLE
Encode "+" as "%2B" in username and password

### DIFF
--- a/src/hnmanager.cpp
+++ b/src/hnmanager.cpp
@@ -75,9 +75,11 @@ void HNManager::authenticate(const QString &username, const QString &password)
     QNetworkRequest req(QUrl(BASE_URL + QLatin1String("/login")));
     req.setHeader(QNetworkRequest::ContentTypeHeader, QLatin1String("application/x-www-form-urlencoded"));
 
+    // QUrlQuery doesn't convert "+" to "&2B" so we must perform this manually
+    // See https://doc.qt.io/qt-5/qurlquery.html#handling-of-spaces-and-plus
     QUrlQuery data;
-    data.addQueryItem(QLatin1String("acct"), username);
-    data.addQueryItem(QLatin1String("pw"), password);
+    data.addQueryItem(QLatin1String("acct"), QString(username).replace("+", "%2B"));
+    data.addQueryItem(QLatin1String("pw"), QString(password).replace("+", "%2B"));
 
     QNetworkReply* reply = network->post(req, data.toString(QUrl::FullyEncoded).toUtf8());
 


### PR DESCRIPTION
QUrlQuery performs URL encoding, except for encoding of spaces and + symbols as would be the case for an HTML form. See:

https://doc.qt.io/qt-5/qurlquery.html#handling-of-spaces-and-plus

Hacker News seems to expect the "+" symbols to be encoded.

As a result, encoding of plus symbols must be performed manually in order for usernames and passwords that include the symbol to work (spaces seem to pass through okay if left as spaces).