### PR TITLE
[Restore] restore the copy external url feature, including translations

### DIFF
--- a/qml/pages/CommentsPage.qml
+++ b/qml/pages/CommentsPage.qml
@@ -80,6 +80,12 @@ Page {
                     share.trigger();
                 }
             }
+            MenuItem {
+                text: qsTr("Copy external URL")
+                onClicked: {
+                    Clipboard.text = url;
+                }
+            }
 
             MenuItem {
                 id: reply

--- a/translations/harbour-sailhn-de.ts
+++ b/translations/harbour-sailhn-de.ts
@@ -9,27 +9,32 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="87"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="84"/>
+        <source>Copy external URL</source>
+        <translation type="unfinished"><Externe URL kopieren/translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CommentsPage.qml" line="93"/>
         <source>Reply</source>
         <translation>Antworten</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="95"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="101"/>
         <source>Refresh</source>
         <translation>Aktualisieren</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="107"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="113"/>
         <source>Load more</source>
         <translation>Mehr laden</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="123"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="129"/>
         <source>Comments</source>
         <translation>Kommentare</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="199"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="205"/>
         <source>Share url</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-sailhn-et.ts
+++ b/translations/harbour-sailhn-et.ts
@@ -9,27 +9,32 @@
         <translation>Jaga</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="87"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="84"/>
+        <source>Copy external URL</source>
+        <translation type="unfinished">Kopeeri väline URL</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CommentsPage.qml" line="93"/>
         <source>Reply</source>
         <translation>Vasta</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="95"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="101"/>
         <source>Refresh</source>
         <translation>Uuenda</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="107"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="113"/>
         <source>Load more</source>
         <translation>Laadi veel</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="123"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="129"/>
         <source>Comments</source>
         <translation>Kommentaarid</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="199"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="205"/>
         <source>Share url</source>
         <translation>Jaga võrguaadressi</translation>
     </message>

--- a/translations/harbour-sailhn-fi.ts
+++ b/translations/harbour-sailhn-fi.ts
@@ -9,27 +9,32 @@
         <translation>Jaa</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="87"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="84"/>
+        <source>Copy external URL</source>
+        <translation type="unfinished">Kopioi ulkoinen osoite</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CommentsPage.qml" line="93"/>
         <source>Reply</source>
         <translation>Vastaa</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="95"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="101"/>
         <source>Refresh</source>
         <translation>Virkistä</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="107"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="113"/>
         <source>Load more</source>
         <translation>Lataa lisää</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="123"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="129"/>
         <source>Comments</source>
         <translation>Kommentit</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="199"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="205"/>
         <source>Share url</source>
         <translation type="unfinished">Jaa url-osoite</translation>
     </message>

--- a/translations/harbour-sailhn-fr.ts
+++ b/translations/harbour-sailhn-fr.ts
@@ -9,27 +9,32 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="87"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="84"/>
+        <source>Copy external URL</source>
+        <translation type="unfinished">Copier l&apos;URL externe</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CommentsPage.qml" line="93"/>
         <source>Reply</source>
         <translation>Répondre</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="95"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="101"/>
         <source>Refresh</source>
         <translation>Rafraîchir</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="107"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="113"/>
         <source>Load more</source>
         <translation>Charger plus</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="123"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="129"/>
         <source>Comments</source>
         <translation>Commentaires</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="199"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="205"/>
         <source>Share url</source>
         <translation type="unfinished"></translation>
     </message>
@@ -98,7 +103,7 @@
     <message>
         <location filename="../qml/pages/Reply.qml" line="42"/>
         <source>Commented!</source>
-        <translation>Commenté&#x202f;!</translation>
+        <translation>Commenté !</translation>
     </message>
     <message>
         <location filename="../qml/pages/Reply.qml" line="57"/>
@@ -212,7 +217,7 @@
     <message>
         <location filename="../qml/pages/Submit.qml" line="40"/>
         <source>Submitted!</source>
-        <translation>Soumis&#x202f;!</translation>
+        <translation>Soumis !</translation>
     </message>
     <message>
         <location filename="../qml/pages/Submit.qml" line="63"/>

--- a/translations/harbour-sailhn-hr.ts
+++ b/translations/harbour-sailhn-hr.ts
@@ -9,27 +9,32 @@
         <translation>Dijeli</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="87"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="84"/>
+        <source>Copy external URL</source>
+        <translation type="unfinished">Kopiraj vanjski URL</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CommentsPage.qml" line="93"/>
         <source>Reply</source>
         <translation>Odgovori</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="95"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="101"/>
         <source>Refresh</source>
         <translation>Aktualiziraj</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="107"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="113"/>
         <source>Load more</source>
         <translation>Učitaj više</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="123"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="129"/>
         <source>Comments</source>
         <translation>Komentari</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="199"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="205"/>
         <source>Share url</source>
         <translation>Dijeli URL</translation>
     </message>

--- a/translations/harbour-sailhn-it.ts
+++ b/translations/harbour-sailhn-it.ts
@@ -9,27 +9,32 @@
         <translation>Condividi</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="87"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="84"/>
+        <source>Copy external URL</source>
+        <translation type="unfinished">Copia URL externo</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CommentsPage.qml" line="93"/>
         <source>Reply</source>
         <translation>Rispondi</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="95"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="101"/>
         <source>Refresh</source>
         <translation>Aggiorna</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="107"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="113"/>
         <source>Load more</source>
         <translation>Mostra altri</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="123"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="129"/>
         <source>Comments</source>
         <translation>Commenti</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="199"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="205"/>
         <source>Share url</source>
         <translation>Condividi url</translation>
     </message>

--- a/translations/harbour-sailhn-lt.ts
+++ b/translations/harbour-sailhn-lt.ts
@@ -9,27 +9,32 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="87"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="84"/>
+        <source>Copy external URL</source>
+        <translation type="unfinished">Kopijuoti išorinį URL</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CommentsPage.qml" line="93"/>
         <source>Reply</source>
         <translation>Atsakyti</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="95"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="101"/>
         <source>Refresh</source>
         <translation>Įkelti iš naujo</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="107"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="113"/>
         <source>Load more</source>
         <translation>Įkelti daugiau</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="123"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="129"/>
         <source>Comments</source>
         <translation>Komentarai</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="199"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="205"/>
         <source>Share url</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-sailhn-nb_NO.ts
+++ b/translations/harbour-sailhn-nb_NO.ts
@@ -9,27 +9,32 @@
         <translation>Del</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="87"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="84"/>
+        <source>Copy external URL</source>
+        <translation type="unfinished">Kopier ekstern nettadresse</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CommentsPage.qml" line="93"/>
         <source>Reply</source>
         <translation>Svar</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="95"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="101"/>
         <source>Refresh</source>
         <translation>Gjenoppfrisk</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="107"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="113"/>
         <source>Load more</source>
         <translation>Last inn flere</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="123"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="129"/>
         <source>Comments</source>
         <translation>Kommentarer</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="199"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="205"/>
         <source>Share url</source>
         <translation>Del lenke</translation>
     </message>

--- a/translations/harbour-sailhn-nl.ts
+++ b/translations/harbour-sailhn-nl.ts
@@ -9,27 +9,32 @@
         <translation>Deel</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="87"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="84"/>
+        <source>Copy external URL</source>
+        <translation type="unfinished">Externe URL kopiëren</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CommentsPage.qml" line="93"/>
         <source>Reply</source>
         <translation>Beantwoorden</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="95"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="101"/>
         <source>Refresh</source>
         <translation>Verversen</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="107"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="113"/>
         <source>Load more</source>
         <translation>Meer laden</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="123"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="129"/>
         <source>Comments</source>
         <translation>Reacties</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="199"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="205"/>
         <source>Share url</source>
         <translation type="unfinished">Deel url</translation>
     </message>

--- a/translations/harbour-sailhn-nl_BE.ts
+++ b/translations/harbour-sailhn-nl_BE.ts
@@ -9,27 +9,32 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="87"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="84"/>
+        <source>Copy external URL</source>
+        <translation type="unfinished">Externen URL kopiëren</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CommentsPage.qml" line="93"/>
         <source>Reply</source>
         <translation>Beantwoorden</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="95"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="101"/>
         <source>Refresh</source>
         <translation>Verversen</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="107"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="113"/>
         <source>Load more</source>
         <translation>Meer laden</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="123"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="129"/>
         <source>Comments</source>
         <translation>Reacties</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="199"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="205"/>
         <source>Share url</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-sailhn-sr.ts
+++ b/translations/harbour-sailhn-sr.ts
@@ -9,27 +9,32 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="87"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="84"/>
+        <source>Copy external URL</source>
+        <translation type="unfinished">Копирај спољни УРЛ</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CommentsPage.qml" line="93"/>
         <source>Reply</source>
         <translation>Узврати</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="95"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="101"/>
         <source>Refresh</source>
         <translation>Освежи</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="107"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="113"/>
         <source>Load more</source>
         <translation>Учитај још</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="123"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="129"/>
         <source>Comments</source>
         <translation>Коментари</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="199"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="205"/>
         <source>Share url</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-sailhn-sv.ts
+++ b/translations/harbour-sailhn-sv.ts
@@ -9,27 +9,32 @@
         <translation>Dela</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="87"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="84"/>
+        <source>Copy external URL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CommentsPage.qml" line="93"/>
         <source>Reply</source>
         <translation>Svara</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="95"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="101"/>
         <source>Refresh</source>
         <translation>Uppdatera</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="107"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="113"/>
         <source>Load more</source>
         <translation>Läs in mer</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="123"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="129"/>
         <source>Comments</source>
         <translation>Kommentarer</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="199"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="205"/>
         <source>Share url</source>
         <translation>Dela URL</translation>
     </message>

--- a/translations/harbour-sailhn-ta.ts
+++ b/translations/harbour-sailhn-ta.ts
@@ -9,27 +9,32 @@
         <translation>பங்கு</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="87"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="84"/>
+        <source>Copy external URL</source>
+        <translation type="unfinished">வெளிப்புற முகவரி ஐ நகலெடுக்கவும்</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CommentsPage.qml" line="93"/>
         <source>Reply</source>
         <translation>பதில்</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="95"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="101"/>
         <source>Refresh</source>
         <translation>புதுப்பிப்பு</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="107"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="113"/>
         <source>Load more</source>
         <translation>மேலும் ஏற்றவும்</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="123"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="129"/>
         <source>Comments</source>
         <translation>கருத்துகள்</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="199"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="205"/>
         <source>Share url</source>
         <translation type="unfinished">முகவரி ஐப் பகிரவும்</translation>
     </message>

--- a/translations/harbour-sailhn-tr.ts
+++ b/translations/harbour-sailhn-tr.ts
@@ -9,27 +9,32 @@
         <translation>Paylaş</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="87"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="84"/>
+        <source>Copy external URL</source>
+        <translation type="unfinished">Harici URL&apos;yi kopyala</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CommentsPage.qml" line="93"/>
         <source>Reply</source>
         <translation>Yanıtla</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="95"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="101"/>
         <source>Refresh</source>
         <translation>Yenile</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="107"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="113"/>
         <source>Load more</source>
         <translation>Daha fazla yükle</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="123"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="129"/>
         <source>Comments</source>
         <translation>Yorumlar</translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="199"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="205"/>
         <source>Share url</source>
         <translation>URL&apos;yi paylaş</translation>
     </message>

--- a/translations/harbour-sailhn.ts
+++ b/translations/harbour-sailhn.ts
@@ -9,27 +9,32 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="87"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="84"/>
+        <source>Copy external URL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/CommentsPage.qml" line="93"/>
         <source>Reply</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="95"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="101"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="107"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="113"/>
         <source>Load more</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="123"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="129"/>
         <source>Comments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/CommentsPage.qml" line="199"/>
+        <location filename="../qml/pages/CommentsPage.qml" line="205"/>
         <source>Share url</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
I have been using copy external URL for years to either make a note, paste into messages in tooter, hydrogen or Fernschreiber. The removal of the copy feature basically meant not using sailhn. Please consider this PR restoring the feature.